### PR TITLE
fix: handle LaTeX expressions in ID generation

### DIFF
--- a/client/src/services/regex.js
+++ b/client/src/services/regex.js
@@ -31,6 +31,12 @@ export function generateId(children) {
   return resId
     .toString()
     .toLowerCase()
+    // Remove LaTeX expressions before processing (e.g., $...$, \[...\], \(...\))
+    .replace(/\$\$[\s\S]*?\$\$/g, "") // remove display math $$...$$
+    .replace(/\$[^$]*?\$/g, "") // remove inline math $...$
+    .replace(/\\\[[\s\S]*?\\\]/g, "") // remove \[...\]
+    .replace(/\\\([\s\S]*?\\\)/g, "") // remove \(...\)
+    .replace(/\\[a-zA-Z]+\{[^}]*\}/g, "") // remove LaTeX commands like \frac{...}
     .replace(/[^a-z0-9\s-]/g, "") // remove special chars except space and hyphen
     .replace(/\s+/g, "-") // replace spaces/tabs with hyphens
     .replace(/-+/g, "-") // collapse multiple hyphens


### PR DESCRIPTION
Fixes #4

Added LaTeX expression removal before generating IDs from titles. The generateId() function now strips:
- Inline math: $...$
- Display math: $$...$$
- Bracket notation: \[...\] and \(...\)
- LaTeX commands: \command{...}

This prevents ID generation failures when titles contain LaTeX mathematical expressions.