### PR TITLE
fix: save draft locally on session expiration

### DIFF
--- a/client/src/pages/Create/Editor/hooks/useWritingPad.js
+++ b/client/src/pages/Create/Editor/hooks/useWritingPad.js
@@ -81,6 +81,12 @@ export function useWritingPad({ postId, frontendOnly, artType, editing }) {
     } catch (error) {
       // saveWrittenPost already shows a toast; log for debugging
       console.error("Error saving post:", error);
+      
+      // Handle session expiration - save draft locally before redirect
+      if (error.response?.status === 401) {
+        saveDraftLocally();
+        toast.error("Session expired - draft saved locally. Please login to continue.");
+      }
     }
   };
 


### PR DESCRIPTION
Fixes #8 - handles logout during post creation by saving draft to localStorage before showing error message.