### PR TITLE
fix: correct typos in README and to-do.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,6 @@ However to accelerate development, I used AI tools (Claude and Gemini) to help d
 
 [*EDIT]: Not by me anymore, we have contributors! And thanks to them the development is going rapidly.
 
-BACKEND: Almost everything done by me. I used claude to document some files as they were too large for me to maintain and documentise in my current time frame. 
+BACKEND: Almost everything done by me. I used claude to document some files as they were too large for me to maintain and document in my current time frame. 
 
 TEST: DB seeding codes & Autocannon, Artillery Test codes written by me, updated with gemini, some test codes are totally AI generated.

--- a/client/to-do.txt
+++ b/client/to-do.txt
@@ -44,7 +44,7 @@ fix it in posts: author: {
 -- contact info not synced on userame update, also rate limit it
 -- [] repost someones post
 -- collectionssssssss
-  no seperate btn to create,
+  no separate btn to create,
   in every post this modal will be present to add things in collection, & create new collection
   you can add private posts also, but it will be hidden when someone clicks like usual
 


### PR DESCRIPTION
Fixed two minor typos:\n\n1. README.md: 'documentise' → 'document'\n2. client/to-do.txt: 'seperate' → 'separate'\n\nThese are small documentation fixes to improve readability.