### PR TITLE
fix: AuthContext uses undefined location.pathname

### DIFF
--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 import PropTypes from "prop-types";
 import { toast } from "sonner";
@@ -24,6 +24,7 @@ export const AuthProvider = ({ children }) => {
   const [error, setError] = useState(null);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const isTokenExpired = (token) => {
     try {


### PR DESCRIPTION
## Bug

The `handleGoogleAuthSuccess` function referenced `location.pathname` but `useLocation` was never called, causing a ReferenceError on Google auth callback.

## Impact

- Google auth callback would crash with `ReferenceError: location is not defined`
- Users would see an error page after Google OAuth redirect

## Fix

Added `useLocation` hook import and call to make `location` available.

- 1 file changed, 2 insertions, 1 deletion